### PR TITLE
Make S3Overrides accessible via E-Var or option.

### DIFF
--- a/lib/optionsFromArguments.js
+++ b/lib/optionsFromArguments.js
@@ -69,9 +69,8 @@ const optionsFromArguments = function optionsFromArguments(args) {
   options = fromEnvironmentOrDefault(options, 'baseUrl', 'S3_BASE_URL', null);
   options = fromEnvironmentOrDefault(options, 'baseUrlDirect', 'S3_BASE_URL_DIRECT', false);
   options = fromEnvironmentOrDefault(options, 'signatureVersion', 'S3_SIGNATURE_VERSION', 'v4');
-  options = fromEnvironmentOrDefault(
-    options, 'globalCacheControl', 'S3_GLOBAL_CACHE_CONTROL', null);
-  options.s3overrides = s3overrides;
+  options = fromEnvironmentOrDefault(options, 'globalCacheControl', 'S3_GLOBAL_CACHE_CONTROL', null);
+  options = fromEnvironmentOrDefault(options, 's3overrides', 'S3_OVERRIDES', s3overrides);
 
   return options;
 }


### PR DESCRIPTION
Background: when using parse server with a config file there is no way to specify S3Override options.
-This change doesn't affect the current method of passing s3overrides = backwards compatible.
-s3overrides would now be accessible by via parse-server config file like this:
"filesAdapter": {
"module":"parse-server-s3-adapter",
"options":{
"s3overrides": { "endpoint": {"protocol":"https:","host":"$FILEURL","port":443,"hostname":"","pathname":"/","path":"/","href":"https:///"},
"s3BucketEndpoint": false,
ANY OTHER S3OVERRIDES GO HERE... },
"baseUrl": "https://",
"directAccess": true,
"accessKey": "",
"secretKey": "",
"bucket": "",
"region": ""
}
}

-OR in theory (I haven't tested) by Environmental variable like so:

S3_OVERRIDES="{ "endpoint": {"protocol":"https:","host":"$FILEURL","port":443,"hostname":"$FILEURL","pathname":"/","path":"/","href":"https://$FILEURL/"},
"s3BucketEndpoint": false,
ANY OTHER S3OVERRIDES GO HERE... }"